### PR TITLE
Update plugin to v3.1.0

### DIFF
--- a/logtosplunk/pom.xml
+++ b/logtosplunk/pom.xml
@@ -3,10 +3,10 @@
     <parent>
         <groupId>com.log-to-splunk</groupId>
         <artifactId>logtosplunk-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <version>3.0.1</version>
+    <version>3.1.0</version>
     <artifactId>logtosplunk</artifactId>
     <dependencies>
         <dependency>

--- a/logtosplunk/pom.xml
+++ b/logtosplunk/pom.xml
@@ -1,36 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>com.splunk</groupId>
+        <groupId>com.log-to-splunk</groupId>
         <artifactId>logtosplunk-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <artifactId>logtosplunk</artifactId>
     <dependencies>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.3</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.2</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
-            <groupId>com.splunk.logging</groupId>
-            <artifactId>splunk-library-javalogging</artifactId>
-            <version>1.8.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.splunk</groupId>
+            <groupId>com.log-to-splunk</groupId>
             <artifactId>shared-mc</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.splunk</groupId>
+            <groupId>com.log-to-splunk</groupId>
             <artifactId>spigot</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -70,15 +65,15 @@
                 <dependency>
                     <groupId>com.splunk.logging</groupId>
                     <artifactId>splunk-library-javalogging</artifactId>
-                    <version>1.8.0</version>
+                    <version>1.11.4</version>
                 </dependency>
                 <dependency>
-                    <groupId>com.splunk</groupId>
+                    <groupId>com.log-to-splunk</groupId>
                     <artifactId>shared-mc</artifactId>
                     <version>${project.version}</version>
                 </dependency>
                 <dependency>
-                    <groupId>com.splunk</groupId>
+                    <groupId>com.log-to-splunk</groupId>
                     <artifactId>spigot</artifactId>
                     <version>${project.version}</version>
                 </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.log-to-splunk</groupId>
     <artifactId>logtosplunk-parent</artifactId>
-    <version>3.0.1</version>
+    <version>3.1.0</version>
     <modules>
         <module>spigot</module>
         <module>shared-mc</module>

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.splunk</groupId>
+    <groupId>com.log-to-splunk</groupId>
     <artifactId>logtosplunk-parent</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <modules>
         <module>spigot</module>
         <module>shared-mc</module>
@@ -20,7 +20,7 @@
         </repository>
         <repository>
             <id>sonatype</id>
-            <url>https://oss.sonatype.org/content/groups/public/</url>
+            <url>https://oss.sonatype.org/content/groups/public/org</url>
         </repository>
         <repository>
             <snapshots>
@@ -33,15 +33,22 @@
         <repository>
             <id>splunk-artifactory</id>
             <name>Splunk Releases</name>
-            <url>http://splunk.artifactoryonline.com/splunk/ext-releases-local</url>
+            <url>https://splunk.jfrog.io/splunk/ext-releases-local</url>
         </repository>
     </repositories>
+    <distributionManagement>
+        <repository>
+            <id>splunk-artifactory</id>
+            <name>Splunk Releases</name>
+            <url>https://splunk.jfrog.io/splunk/ext-releases-local</url>
+        </repository>
+    </distributionManagement>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>com.splunk.logging</groupId>
                 <artifactId>splunk-library-javalogging</artifactId>
-                <version>1.8.0</version>
+                <version>1.11.4</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
@@ -61,7 +68,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>[4.13.1,)</version>
+                <version>4.13.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/shared-mc/pom.xml
+++ b/shared-mc/pom.xml
@@ -3,33 +3,35 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>com.splunk</groupId>
+        <groupId>com.log-to-splunk</groupId>
         <artifactId>logtosplunk-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <artifactId>shared-mc</artifactId>
     <dependencies>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
+            <version>2.17.0</version>
             <!--<version>2.6.1</version>-->
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
+            <version>2.17.0</version>
             <!--<version>2.6.1</version>-->
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>31.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.7</version>
+            <version>2.8.9</version>
         </dependency>
         <dependency>
             <groupId>com.splunk.logging</groupId>
@@ -38,6 +40,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
@@ -47,7 +50,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <version>4.13.2</version>
         </dependency>
     </dependencies>
 

--- a/shared-mc/pom.xml
+++ b/shared-mc/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>com.log-to-splunk</groupId>
         <artifactId>logtosplunk-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <version>3.0.1</version>
+    <version>3.1.0</version>
     <artifactId>shared-mc</artifactId>
     <dependencies>
         <dependency>

--- a/spigot/pom.xml
+++ b/spigot/pom.xml
@@ -3,12 +3,12 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>com.splunk</groupId>
+        <groupId>com.log-to-splunk</groupId>
         <artifactId>logtosplunk-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <artifactId>spigot</artifactId>
 
     <build>
@@ -29,22 +29,12 @@
             </resource>
         </resources>
     </build>
-    <repositories>
-        <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-        <repository>
-            <id>sonatype</id>
-            <url>https://oss.sonatype.org/content/groups/public/</url>
-        </repository>
-    </repositories>
     <dependencies>
         <!--Spigot-API-->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.15.2-R0.1-SNAPSHOT</version>
+            <version>1.18.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!--Bukkit API-->
@@ -58,13 +48,15 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
-            <groupId>com.splunk</groupId>
+            <groupId>com.log-to-splunk</groupId>
             <artifactId>shared-mc</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/spigot/pom.xml
+++ b/spigot/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>com.log-to-splunk</groupId>
         <artifactId>logtosplunk-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <version>3.0.1</version>
+    <version>3.1.0</version>
     <artifactId>spigot</artifactId>
 
     <build>

--- a/spigot/src/main/resources/plugin.yml
+++ b/spigot/src/main/resources/plugin.yml
@@ -2,6 +2,6 @@ name: LogToSplunk
 main: com.splunk.spigot.LogToSplunkPlugin
 version: ${project.version}
 description: This plugin registers event handlers and logs events to Splunk via the Splunk HTTP Event Collector.
-author: PowerSchill
-website: https://github.com/PowerSchill/LogToSplunk
-api-version: 1.15
+author: PowerSchill and Jimmy Maple
+website: https://github.com/jimmyatSplunk/LogToSplunk
+api-version: 1.18


### PR DESCRIPTION
- Updated for Spigot 1.18+
- Updated repository information for Splunk logging artifact
- Removed repository information from "spigot" module to stop build issues
- Upgraded multiple dependencies to address vulnerabilities
- Renamed groupId for LogToSplunk-specific modules